### PR TITLE
Fix for post 4.8.3

### DIFF
--- a/enhanced-post-cache.php
+++ b/enhanced-post-cache.php
@@ -100,7 +100,14 @@ class Enhanced_Post_Cache {
 		}
 
 		global $wpdb;
-		$this->cache_key = md5( $sql );
+		
+		$query = $sql;
+		// Check if method existing before using it for backwards compat
+		if( method_exists( $wpdb, 'remove_placeholder_escape' ) ) {
+			// Remove placeholders, as they would break the cache key for searches.
+			$query = $wpdb->remove_placeholder_escape( $query );
+		}
+		$this->cache_key = md5( $query );
 		$this->found_posts = 0;
 		$this->all_post_ids = wp_cache_get( $this->cache_key . $this->cache_salt, $this->cache_group );
 


### PR DESCRIPTION
As for WordPress 4.8.3 (see https://github.com/WordPress/WordPress/commit/a2693fd8602e3263b5925b9d799ddd577202167d), core added placeholders in queries that contain like searches. This was a security messure to help escape this type of query. 

However, these placeholder, would mess up how cache keys are generated in this plugin, as the placeholder is different on each request. This PR, simply removes the placeholders using a core function. 